### PR TITLE
Custom checkpatch command support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM webispy/checkpatch
 
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		gawk \
+		&& apt-get clean \
+		&& rm -rf /var/lib/apt/lists/*
+
 COPY entrypoint.sh /entrypoint.sh
 COPY review.sh /review.sh
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,25 @@ jobs:
       uses: webispy/checkpatch-action@master
 ```
 
+For using a custom checkpatch script, pass the `CHECKPATCH_COMMAND` environment
+variable. For example, for DPDK's `checkpatches.sh` script use:
+
+```yml
+name: checkpatch review
+on: [pull_request]
+jobs:
+  my_review:
+    name: checkpatch review
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Run DPDK checkpatches.sh review
+      uses: webispy/checkpatch-action@master
+      env:
+        DPDK_CHECKPATCH_PATH: /usr/bin/checkpatch.pl
+        CHECKPATCH_COMMAND: ./devtools/checkpatches.sh
+```
+
 ## References
 
 ### checkpatch tool

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,8 +20,10 @@ RESULT=0
 echo
 if [[ -z "$GITHUB_TOKEN" ]]; then
     echo -e "\e[0;34mToken is empty. Review PR without comments.\e[0m"
+    HEADERS=()
 else
     echo -e "\e[0;34mReview PR with comments.\e[0m"
+    HEADERS=(-H "Authorization: Bearer $GITHUB_TOKEN")
 fi
 
 # Get commit list using Github API
@@ -32,7 +34,7 @@ PRNUM=${PR%"/merge"}
 URL=https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${PRNUM}/commits
 echo " - API endpoint: $URL"
 
-list=$(curl $URL -X GET -s | jq '.[].sha' -r)
+list=$(curl $URL "${HEADERS[@]}" -X GET -s | jq '.[].sha' -r)
 len=$(echo "$list" | wc -l)
 echo " - Commits $len: $list"
 

--- a/review.sh
+++ b/review.sh
@@ -3,9 +3,13 @@
 # To debug the current script, please uncomment the following 'set -x' line
 #set -x
 
+if [[ -z "$CHECKPATCH_COMMAND" ]] ; then
+    CHECKPATCH_COMMAND="checkpatch.pl --no-tree"
+fi
+
 # Generate email style commit message
 PATCH_FILE=$(git format-patch $1 -1)
-PATCHMAIL=$(checkpatch.pl --no-tree $PATCH_FILE)
+PATCHMAIL=$($CHECKPATCH_COMMAND $PATCH_FILE)
 
 # Internal state variables
 RESULT=0

--- a/review.sh
+++ b/review.sh
@@ -4,7 +4,8 @@
 #set -x
 
 # Generate email style commit message
-PATCHMAIL=$(git show --format=email $1 | checkpatch.pl --no-tree -)
+PATCH_FILE=$(git format-patch $1 -1)
+PATCHMAIL=$(checkpatch.pl --no-tree $PATCH_FILE)
 
 # Internal state variables
 RESULT=0


### PR DESCRIPTION
This pull request allows customizing the checkpatch command used within the action. It allows for example to use DPDK's checkpatches.sh script (as shown in the README excerpt).

The request also includes a couple of changes specifically for DPDK:

* DPDK checkpatches.sh requires gawk rather than mawk.
* It works better with a file input rather than stdin, and with git-format-patch instead of git-show.

Finally, the changes also include passing the provided authorization token to github if it is set (to support private repositories).