### PR TITLE
Add note on `GITHUB_TOKEN` usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,25 @@ jobs:
         CHECKPATCH_COMMAND: ./devtools/checkpatches.sh
 ```
 
+**Note:** For **private repositories** this action needs access to the `GITHUB_TOKEN`. It needs read access to `contents` and `pull-requests` as minimum permissions. For example:
+```yml
+name: checkpatch review
+on: [pull_request]
+jobs:
+  my_review:
+    name: checkpatch review
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+    - uses: actions/checkout@v1
+    - name: Run checkpatch review
+      uses: webispy/checkpatch-action@master
+      env:
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+```
+
 ## References
 
 ### checkpatch tool


### PR DESCRIPTION
Hi, I just had this problem and it took me a while to figure out what was wrong with my setup. I think it would be a good hint to others: When using this action with a private repository they need to pass the `GITHUB_TOKEN` to the action.

When not giving the action access to the token, it fails silently:
```
Review PR with comments.
Get the list of commits included in the PR(refs/pull/1/merge).
 - API endpoint: https://api.github.com/repos/gschwaer/checkpatch-action-test/pulls/1/commits
jq: error (at <stdin>:4): Cannot index string with string "sha"
 - Commits 1: 
Start review for each commits.
Done
```
It'll show as successful job completion.