### PR TITLE
remove duplicated installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,5 @@
 FROM webispy/checkpatch
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		gawk \
-		&& apt-get clean \
-		&& rm -rf /var/lib/apt/lists/*
-
 COPY entrypoint.sh /entrypoint.sh
 COPY review.sh /review.sh
 


### PR DESCRIPTION
The `gawk` package is already provided in the `webispy/checkpatch`
docker image.

Signed-off-by: Inho Oh <webispy@gmail.com>