### PR TITLE
Pin docker image digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM webispy/checkpatch
+FROM webispy/checkpatch@sha256:e84b5049be1410395ecca4547e14b1d209fb9f3327383bef83b25aeb666a8304
 
 COPY entrypoint.sh /entrypoint.sh
 COPY review.sh /review.sh


### PR DESCRIPTION
This reduces the consequence of a base image for this action being
tampered with, since action consumers can pin the action sha and
be a bit more sure what code is running.

Are you open for this change, do you want to move the github workflows to the `master` branch as well?