### PR TITLE
add version tag to docker image

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -18,9 +18,9 @@ jobs:
       - name: Available platforms
         run: echo ${{ steps.buildx.outputs.platforms }}
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           platforms: linux/amd64,linux/arm64
           push: false
-          tags: webispy/checkpatch
+          tags: webispy/checkpatch:latest,webispy/checkpatch:1.0.0

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -28,4 +28,4 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: webispy/checkpatch
+          tags: webispy/checkpatch:latest,webispy/checkpatch:1.0.0


### PR DESCRIPTION
Add a version tag to Docker images so that changes can be tracked. The `latest` tag is also provided so that the latest version can always be used if no tag is specified.

Signed-off-by: Inho Oh <webispy@gmail.com>