### PR TITLE
Automate updating digest

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -24,8 +24,19 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Build and push
         uses: docker/build-push-action@v3
+        id: build-and-push
         with:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
           tags: webispy/checkpatch
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+      - name: Update Dockerfile in default branch with digest
+        run: sed -ri 's#(FROM webispy/checkpatch@).*#\1${{ steps.build-and-push.outputs.digest }}#' Dockerfile
+      - name: Create Pull Request with updated Dockerfile
+        uses: peter-evans/create-pull-request@v4
+        with:
+          commit-message: Roll Dockerfile digest
+          base: ${{ github.event.repository.default_branch }}

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -38,5 +38,13 @@ jobs:
       - name: Create Pull Request with updated Dockerfile
         uses: peter-evans/create-pull-request@v4
         with:
-          commit-message: Roll Dockerfile digest
-          base: ${{ github.event.repository.default_branch }}
+          title: Roll Dockerfile digest
+          body: |
+            Update action Dockerfile base image with the latest digest:
+            ${{ steps.build-and-push.outputs.digest }}
+          commit-message: |
+            Roll Dockerfile digest
+
+            Update action Dockerfile base image with the latest digest:
+            ${{ steps.build-and-push.outputs.digest }}
+          signoff: true

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -48,3 +48,4 @@ jobs:
             Update action Dockerfile base image with the latest digest:
             ${{ steps.build-and-push.outputs.digest }}
           signoff: true
+          base: ${{ github.event.repository.default_branch }}


### PR DESCRIPTION
On docker image publish, this creates a PR against the default branch (master) to update the Dockerfile there with the fresh digest.
 
I've verified this in a test-repo and should work.

Note that when creating pull requests from workflows the new PR will not trigger yet more workflows in that PR. To work around that you can change this to a pass a personal access token. Like described here: https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#workarounds-to-trigger-further-workflow-runs 