### PR TITLE
checkpatch: ignore UNKNOWN_COMMIT_ID

### DIFF
--- a/review.sh
+++ b/review.sh
@@ -4,7 +4,7 @@
 #set -x
 
 if [[ -z "$CHECKPATCH_COMMAND" ]] ; then
-    CHECKPATCH_COMMAND="checkpatch.pl --no-tree"
+    CHECKPATCH_COMMAND="checkpatch.pl --no-tree --ignore UNKNOWN_COMMIT_ID"
 fi
 
 # Generate email style commit message


### PR DESCRIPTION
Set checkpatch option to ignore unresolved/missing SHA (commit) references in commit text.

Checkpatch will by default try to resolve SHA (commit) references in commit text, and emit a warning if unable to do so. Since the script is not run with a git tree, it will always fail to resolve/find these commits. Hence, specify that checkpatch shall ignore any such failure.